### PR TITLE
Add ruby-head and update 2.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
   - bin/setup_travis
   - psql -c 'create database travis_ci_test;' -U postgres
   - cp ./.travis/database.yml.travis config/database.yml
+  - gem install bundler:1.17.1
   - bundle install
   - RAILS_ENV=test bundle exec rails db:create
   - RAILS_ENV=test bundle exec rails db:migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ cache: bundler
 dist: trusty
 
 rvm:
-  - 2.5.0
+  - 2.5.3
+  - ruby-head
 
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ addons:
   chrome: stable
   postgresql: '9.4'
 
+before_install:
+  - gem install bundler:2.0.1
+
 before_script:
   - bin/setup_travis
   - psql -c 'create database travis_ci_test;' -U postgres
   - cp ./.travis/database.yml.travis config/database.yml
-  - gem install bundler:1.17.1
   - bundle install
   - RAILS_ENV=test bundle exec rails db:create
   - RAILS_ENV=test bundle exec rails db:migrate

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 
 rvm:
   - 2.5.3
+  - 2.6.1
   - ruby-head
 
 services:

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '2.5.0'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ end
 gem 'rails', github: 'rails/rails'
 
 gem 'bootstrap'
+gem 'bundler', '2.0.1'
 gem 'coffee-rails'
 gem 'jbuilder'
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: d87afbf46f87a7fb8e9fef5c1b8422cdf386f4cb
+  revision: 713cee01a5391b1ca56e25883c6c172ae59d7020
   specs:
     actioncable (6.0.0.beta1)
       actionpack (= 6.0.0.beta1)
@@ -302,6 +302,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap
+  bundler (= 2.0.1)
   byebug
   capybara
   coffee-rails
@@ -329,4 +330,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.17.1
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,8 +328,5 @@ DEPENDENCIES
   web-console
   webmock
 
-RUBY VERSION
-   ruby 2.5.0p0
-
 BUNDLED WITH
    1.17.1


### PR DESCRIPTION
Why don't we have a tea party with ruby-head?