### PR TITLE
Fix client initialize bug

### DIFF
--- a/app/lib/twitter_client.rb
+++ b/app/lib/twitter_client.rb
@@ -1,6 +1,6 @@
 class TwitterClient
   def self.client(access_token, access_token_secret)
-    @client ||= Twitter::REST::Client.new do |config|
+    Twitter::REST::Client.new do |config|
       config.consumer_key = ENV['CONSUMER_KEY']
       config.consumer_secret = ENV['CONSUMER_SECRET']
       config.access_token = access_token


### PR DESCRIPTION
クライアントの生成方法が間違っていて、最初のユーザーのツイートしか取得できていなかったので修正