### PR TITLE
Ignore ruby-head result in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,7 @@ before_script:
 
 script:
   - bundle exec rails test:system
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
I think ruby-head result is not important for this app.