### PR TITLE
Add bundle volume in Dockerfile makes needless re bundle install afte…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN chmod +x /usr/bin/entrypoint.sh
 ENTRYPOINT ["entrypoint.sh"]
 EXPOSE 3000
 
+VOLUME /usr/local/bundle
+
 #RUN if [ "$RAILS_ENV" = "production" ]; then SECRET_KEY_BASE=$(bundle exec rails secret) bundle exec rails assets:precompile; fi
 
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
…r docker copose up

Dockerfile VOLUME directive cannot take name.
So it cannot be sync `Dockerfile VOLUME` and `docker compose named volume`.
But anonymouse volume can be set with docker compose volume directive.

So we do not have to execute bundle install after first `docker compose up`

ref: https://github.com/moby/moby/issues/30647