### PR TITLE
Fix postgres sql container version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   db:
-    image: postgres
+    image: postgres:15.1
     volumes:
       - type: volume
         source: favoreyo-db-volume


### PR DESCRIPTION
because of https://github.com/colorbox/favoreyo/actions/runs/3721504503/jobs/6311700907 job failed Its db container fails start.
Because of pulling latest image version, incompatible 14 and 15. This PR fix db container version for `15.1`.

```
PostgreSQL Database directory appears to contain a database; Skipping initialization

2022-12-18 05:54:40.794 UTC [1] FATAL:  database files are incompatible with server
2022-12-18 05:54:40.794 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 14, which is not compatible with this version 15.1 (Debian 15.1-1.pgdg110+1).
```